### PR TITLE
Integrate D3 diagram editor skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# VisualDecisions
-A WordPress Plugin to allow for visual decision trees and for those endpoints to be resources in the site.
+# Visual Decisions
+
+This plugin provides a simple framework for creating and embedding visual decision trees within WordPress. Each diagram is stored as its own custom post type so you can manage them from a dedicated **Visual Decisions** menu in the admin area.
+
+## Features
+
+- **Custom Post Type** `vd_diagram` for storing diagrams.
+- **D3 Powered Editor** inside the post edit screen to drag and drop nodes.
+- **Shortcode** `[vd_diagram id="123"]` renders the saved diagram using D3 on the front‑end.
+
+This plugin now enqueues the D3 library in both the admin and the front‑end. Basic JavaScript files (`vd-editor.js` and `vd-frontend.js`) demonstrate how D3 can be used to build and view diagrams.

--- a/js/vd-editor.js
+++ b/js/vd-editor.js
@@ -1,0 +1,39 @@
+// Admin D3 editor placeholder
+(function($){
+    // get textarea containing JSON data
+    var textarea = document.querySelector('textarea[name="vd_tree_data"]');
+    if (!textarea) return;
+
+    var data;
+    try {
+        data = JSON.parse(textarea.value || '{}');
+    } catch(e) {
+        data = { nodes: [], links: [] };
+    }
+
+    // basic svg setup using D3
+    var svg = d3.select('#vd-editor').append('svg')
+        .attr('width', '100%')
+        .attr('height', 400);
+
+    // render nodes from data
+    function render() {
+        var nodes = svg.selectAll('circle').data(data.nodes);
+        nodes.enter().append('circle')
+            .attr('r', 20)
+            .attr('cx', function(d){ return d.x; })
+            .attr('cy', function(d){ return d.y; })
+            .call(d3.drag()
+                .on('drag', function(event, d){
+                    d.x = event.x;
+                    d.y = event.y;
+                    d3.select(this)
+                        .attr('cx', d.x)
+                        .attr('cy', d.y);
+                    textarea.value = JSON.stringify(data);
+                }));
+        nodes.exit().remove();
+    }
+
+    render();
+})(jQuery);

--- a/js/vd-frontend.js
+++ b/js/vd-frontend.js
@@ -1,0 +1,25 @@
+// Frontend diagram display using D3
+(function(){
+    document.querySelectorAll('.vd-diagram').forEach(function(container){
+        var dataAttr = container.getAttribute('data-diagram');
+        if (!dataAttr) return;
+        var data;
+        try {
+            data = JSON.parse(dataAttr);
+        } catch(e) {
+            return;
+        }
+        var svg = d3.select(container).append('svg')
+            .attr('width', '100%')
+            .attr('height', 400);
+
+        // simple rendering of nodes
+        svg.selectAll('circle')
+            .data(data.nodes || [])
+            .enter()
+            .append('circle')
+            .attr('r', 20)
+            .attr('cx', function(d){ return d.x; })
+            .attr('cy', function(d){ return d.y; });
+    });
+})();

--- a/visual-decisions.php
+++ b/visual-decisions.php
@@ -1,0 +1,90 @@
+<?php
+/*
+Plugin Name: Visual Decisions
+Description: Create visual decision trees with diagram editor and shortcode support.
+Version: 0.1.0
+Author: Auto Generated
+*/
+
+// Register custom post type for diagrams
+function vd_register_post_type() {
+    $labels = array(
+        'name' => 'Visual Decisions',
+        'singular_name' => 'Visual Decision',
+        'add_new' => 'Add New',
+        'add_new_item' => 'Add New Diagram',
+        'edit_item' => 'Edit Diagram',
+        'new_item' => 'New Diagram',
+        'view_item' => 'View Diagram',
+        'search_items' => 'Search Diagrams',
+    );
+
+    register_post_type( 'vd_diagram', array(
+        'labels' => $labels,
+        'public' => false,
+        'show_ui' => true,
+        'show_in_menu' => true,
+        'supports' => array( 'title' ),
+    ) );
+}
+add_action( 'init', 'vd_register_post_type' );
+
+// Add meta box for diagram JSON
+function vd_add_diagram_metabox() {
+    add_meta_box(
+        'vd_diagram_data',
+        'Diagram Data',
+        'vd_diagram_metabox_html',
+        'vd_diagram',
+        'normal',
+        'default'
+    );
+}
+add_action( 'add_meta_boxes', 'vd_add_diagram_metabox' );
+
+function vd_diagram_metabox_html( $post ) {
+    $data = get_post_meta( $post->ID, '_vd_tree_data', true );
+    echo '<textarea name="vd_tree_data" style="width:100%;height:200px;">' . esc_textarea( $data ) . '</textarea>';
+    echo '<div id="vd-editor" style="margin-top:10px;"></div>';
+    echo '<p>Use the editor above to arrange your diagram.</p>';
+}
+
+function vd_save_diagram_meta( $post_id ) {
+    if ( array_key_exists( 'vd_tree_data', $_POST ) ) {
+        update_post_meta( $post_id, '_vd_tree_data', wp_unslash( $_POST['vd_tree_data'] ) );
+    }
+}
+add_action( 'save_post_vd_diagram', 'vd_save_diagram_meta' );
+
+// Shortcode to display a diagram
+function vd_diagram_shortcode( $atts ) {
+    $atts = shortcode_atts( array( 'id' => 0 ), $atts );
+    $id = intval( $atts['id'] );
+    if ( ! $id ) {
+        return '';
+    }
+    $data = get_post_meta( $id, '_vd_tree_data', true );
+    if ( ! $data ) {
+        return '';
+    }
+    // Placeholder container for frontend script
+    return '<div class="vd-diagram" data-diagram="' . esc_attr( $data ) . '"></div>';
+}
+add_shortcode( 'vd_diagram', 'vd_diagram_shortcode' );
+
+// Enqueue D3 and custom scripts in admin
+function vd_admin_scripts( $hook ) {
+    if ( 'vd_diagram' !== get_post_type() ) {
+        return;
+    }
+    wp_enqueue_script( 'd3', 'https://d3js.org/d3.v7.min.js' );
+    wp_enqueue_script( 'vd-editor', plugins_url( 'js/vd-editor.js', __FILE__ ), array( 'd3', 'jquery' ), '0.1', true );
+}
+add_action( 'admin_enqueue_scripts', 'vd_admin_scripts' );
+
+// Enqueue D3 and frontend renderer
+function vd_frontend_scripts() {
+    wp_enqueue_script( 'd3', 'https://d3js.org/d3.v7.min.js' );
+    wp_enqueue_script( 'vd-frontend', plugins_url( 'js/vd-frontend.js', __FILE__ ), array( 'd3' ), '0.1', true );
+}
+add_action( 'wp_enqueue_scripts', 'vd_frontend_scripts' );


### PR DESCRIPTION
## Summary
- integrate D3 library for backend and frontend diagram editing
- add admin and frontend scripts for D3 interaction
- update README with D3-based features

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861565ae1c0832a9def57c83de89216