### PR TITLE
Integrate D3 diagram editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# VisualDecisions
-A WordPress Plugin to allow for visual decision trees and for those endpoints to be resources in the site.
+# Visual Decisions
+
+This plugin provides a simple framework for creating and embedding visual decision trees within WordPress. Each diagram is stored as its own custom post type so you can manage them from a dedicated **Visual Decisions** menu in the admin area.
+
+## Features
+
+- **Custom Post Type** `vd_diagram` for storing diagrams.
+- **D3 Powered Editor** inside the post edit screen. Double‑click the canvas to add nodes, click one node then another to create a connection and drag nodes around.
+- **Shortcode** `[vd_diagram id="123"]` renders the saved diagram using D3 on the front‑end.
+
+The plugin enqueues the D3 library in both the admin and the front‑end. The accompanying JavaScript files (`vd-editor.js` and `vd-frontend.js`) handle basic editing and rendering of diagrams.
+
+## Usage
+
+1. Activate the plugin in WordPress.
+2. Navigate to **Visual Decisions → Add New** and build your diagram with the D3 editor.
+3. Publish the diagram and embed it in any post or page with `[vd_diagram id="123"]`, replacing `123` with the diagram ID.

--- a/js/vd-editor.js
+++ b/js/vd-editor.js
@@ -1,0 +1,101 @@
+// Admin D3 editor with basic add/connect functionality
+(function($){
+    var textarea = document.querySelector('textarea[name="vd_tree_data"]');
+    if(!textarea) return;
+
+    var data;
+    try {
+        data = JSON.parse(textarea.value || '{}');
+    } catch(e) {
+        data = {nodes:[], links:[]};
+    }
+    data.nodes = data.nodes || [];
+    data.links = data.links || [];
+
+    function save(){
+        textarea.value = JSON.stringify(data);
+    }
+
+    var width = document.getElementById('vd-editor').clientWidth || 600;
+    var height = 400;
+    var svg = d3.select('#vd-editor').append('svg')
+        .attr('width', width)
+        .attr('height', height)
+        .style('border', '1px solid #ccc');
+
+    var selected = null;
+
+    function findNode(id){
+        return data.nodes.find(function(n){ return n.id === id; });
+    }
+
+    function render(){
+        // links
+        var linkSel = svg.selectAll('line').data(data.links);
+        linkSel.enter().append('line')
+            .attr('stroke', '#000');
+        linkSel
+            .attr('x1', function(d){ return findNode(d.source).x; })
+            .attr('y1', function(d){ return findNode(d.source).y; })
+            .attr('x2', function(d){ return findNode(d.target).x; })
+            .attr('y2', function(d){ return findNode(d.target).y; });
+        linkSel.exit().remove();
+
+        // nodes
+        var nodeSel = svg.selectAll('g.node').data(data.nodes, function(d){ return d.id; });
+        var nodeEnter = nodeSel.enter().append('g').attr('class','node');
+        nodeEnter.append('circle')
+            .attr('r',20)
+            .attr('fill','#aaf');
+        nodeEnter.append('text')
+            .attr('text-anchor','middle')
+            .attr('dy',4)
+            .text(function(d){ return d.text; });
+
+        nodeSel = nodeEnter.merge(nodeSel);
+        nodeSel.attr('transform', function(d){ return 'translate(' + d.x + ',' + d.y + ')'; });
+
+        nodeSel.select('circle').call(d3.drag()
+            .on('drag', function(event,d){
+                d.x = event.x; d.y = event.y;
+                d3.select(this.parentNode).attr('transform','translate('+d.x+','+d.y+')');
+                render();
+                save();
+            }));
+
+        nodeSel.on('click', function(event,d){
+            if(selected && selected !== d){
+                data.links.push({source:selected.id, target:d.id});
+                selected = null;
+                render();
+                save();
+            } else {
+                selected = d;
+            }
+        }).on('dblclick', function(event,d){
+            var t = prompt('Node text', d.text || '');
+            if(t !== null){
+                d.text = t;
+                d3.select(this).select('text').text(t);
+                save();
+            }
+        });
+
+        nodeSel.exit().remove();
+    }
+
+    svg.on('dblclick', function(event){
+        var coords = d3.pointer(event);
+        var node = {
+            id: 'n' + Date.now(),
+            x: coords[0],
+            y: coords[1],
+            text: 'Question'
+        };
+        data.nodes.push(node);
+        render();
+        save();
+    });
+
+    render();
+})(jQuery);

--- a/js/vd-frontend.js
+++ b/js/vd-frontend.js
@@ -1,0 +1,51 @@
+// Frontend diagram display using D3
+(function(){
+    document.querySelectorAll('.vd-diagram').forEach(function(container){
+        var dataAttr = container.getAttribute('data-diagram');
+        if(!dataAttr) return;
+        var data;
+        try {
+            data = JSON.parse(dataAttr);
+        } catch(e) {
+            return;
+        }
+        data.nodes = data.nodes || [];
+        data.links = data.links || [];
+
+        var width = container.clientWidth || 600;
+        var height = 400;
+        var svg = d3.select(container).append('svg')
+            .attr('width', width)
+            .attr('height', height);
+
+        function findNode(id){
+            return data.nodes.find(function(n){ return n.id === id; });
+        }
+
+        svg.selectAll('line')
+            .data(data.links)
+            .enter()
+            .append('line')
+            .attr('stroke','#000')
+            .attr('x1', function(d){ return findNode(d.source).x; })
+            .attr('y1', function(d){ return findNode(d.source).y; })
+            .attr('x2', function(d){ return findNode(d.target).x; })
+            .attr('y2', function(d){ return findNode(d.target).y; });
+
+        var node = svg.selectAll('g.node')
+            .data(data.nodes)
+            .enter()
+            .append('g')
+            .attr('class','node')
+            .attr('transform', function(d){ return 'translate(' + d.x + ',' + d.y + ')'; });
+
+        node.append('circle')
+            .attr('r',20)
+            .attr('fill','#aaf');
+
+        node.append('text')
+            .attr('text-anchor','middle')
+            .attr('dy',4)
+            .text(function(d){ return d.text; });
+    });
+})();

--- a/visual-decisions.php
+++ b/visual-decisions.php
@@ -1,0 +1,95 @@
+<?php
+/*
+Plugin Name: Visual Decisions
+Description: Create visual decision trees with diagram editor and shortcode support.
+Version: 0.1.0
+Author: Auto Generated
+*/
+
+// Register custom post type for diagrams
+function vd_register_post_type() {
+    $labels = array(
+        'name' => 'Visual Decisions',
+        'singular_name' => 'Visual Decision',
+        'add_new' => 'Add New',
+        'add_new_item' => 'Add New Diagram',
+        'edit_item' => 'Edit Diagram',
+        'new_item' => 'New Diagram',
+        'view_item' => 'View Diagram',
+        'search_items' => 'Search Diagrams',
+    );
+
+    register_post_type( 'vd_diagram', array(
+        'labels' => $labels,
+        'public' => false,
+        'show_ui' => true,
+        'show_in_menu' => true,
+        'menu_icon' => 'dashicons-share',
+        'supports' => array( 'title' ),
+    ) );
+}
+add_action( 'init', 'vd_register_post_type' );
+
+// Add meta box for diagram JSON
+function vd_add_diagram_metabox() {
+    add_meta_box(
+        'vd_diagram_data',
+        'Diagram Data',
+        'vd_diagram_metabox_html',
+        'vd_diagram',
+        'normal',
+        'default'
+    );
+}
+add_action( 'add_meta_boxes', 'vd_add_diagram_metabox' );
+
+function vd_diagram_metabox_html( $post ) {
+    $data = get_post_meta( $post->ID, '_vd_tree_data', true );
+    wp_nonce_field( 'vd_save_diagram', 'vd_diagram_nonce' );
+    echo '<textarea name="vd_tree_data" style="display:none;">' . esc_textarea( $data ) . '</textarea>';
+    echo '<div id="vd-editor" style="margin-top:10px;"></div>';
+    echo '<p>Use the editor above to arrange your diagram.</p>';
+}
+
+function vd_save_diagram_meta( $post_id ) {
+    if ( ! isset( $_POST['vd_diagram_nonce'] ) || ! wp_verify_nonce( $_POST['vd_diagram_nonce'], 'vd_save_diagram' ) ) {
+        return;
+    }
+    if ( array_key_exists( 'vd_tree_data', $_POST ) ) {
+        update_post_meta( $post_id, '_vd_tree_data', wp_unslash( $_POST['vd_tree_data'] ) );
+    }
+}
+add_action( 'save_post_vd_diagram', 'vd_save_diagram_meta' );
+
+// Shortcode to display a diagram
+function vd_diagram_shortcode( $atts ) {
+    $atts = shortcode_atts( array( 'id' => 0 ), $atts );
+    $id = intval( $atts['id'] );
+    if ( ! $id ) {
+        return '';
+    }
+    $data = get_post_meta( $id, '_vd_tree_data', true );
+    if ( ! $data ) {
+        return '';
+    }
+    // Placeholder container for frontend script
+    return '<div class="vd-diagram" data-diagram="' . esc_attr( $data ) . '"></div>';
+}
+add_shortcode( 'vd_diagram', 'vd_diagram_shortcode' );
+
+// Enqueue D3 and custom scripts in admin
+function vd_admin_scripts( $hook ) {
+    if ( 'vd_diagram' !== get_post_type() ) {
+        return;
+    }
+    wp_enqueue_script( 'd3', 'https://d3js.org/d3.v7.min.js' );
+    wp_enqueue_script( 'vd-editor', plugins_url( 'js/vd-editor.js', __FILE__ ), array( 'd3', 'jquery' ), '0.1', true );
+}
+add_action( 'admin_enqueue_scripts', 'vd_admin_scripts' );
+
+// Enqueue D3 and frontend renderer
+function vd_frontend_scripts() {
+    wp_enqueue_script( 'd3', 'https://d3js.org/d3.v7.min.js' );
+    wp_enqueue_script( 'vd-frontend', plugins_url( 'js/vd-frontend.js', __FILE__ ), array( 'd3' ), '0.1', true );
+}
+add_action( 'wp_enqueue_scripts', 'vd_frontend_scripts' );


### PR DESCRIPTION
## Summary
- introduce a custom post type for Visual Decisions
- add interactive D3 editor and renderer
- secure the diagram meta box with a nonce and hide the raw JSON
- document plugin usage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6861565ae1c0832a9def57c83de89216