### PR TITLE
Add interactive question flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # Visual Decisions
 
 This plugin provides a simple framework for creating and embedding visual decision trees within WordPress. Each diagram is stored as its own custom post type so you can manage them from a dedicated **Visual Decisions** menu in the admin area.
+The editor lets you build a flow of multiple-choice questions and the front-end renders an interactive questionnaire for users.
 
 ## Features
 
 - **Custom Post Type** `vd_diagram` for storing diagrams.
 - **D3 Powered Editor** inside the post edit screen. Double-click the canvas to add nodes, click one node then another to create a connection, and drag nodes around.
 - When connecting nodes you will be prompted for a branch label (e.g., "Yes" or "No").
-- **Shortcode** `[vd_diagram id="123"]` renders the saved diagram using D3 on the front‑end.
+- **Shortcode** `[vd_diagram id="123"]` renders an interactive question flow on the front‑end. Each question is presented with buttons for the available answers and progresses through the diagram.
 
-The plugin bundles the D3 library locally so it works without relying on a CDN. Both the admin and the front‑end load this script along with `vd-editor.js` and `vd-frontend.js` for basic editing and rendering of diagrams.
+The plugin bundles the D3 library locally for the editor only. The front‑end script `vd-frontend.js` renders the question flow without D3 so there is no dependency for visitors.
 
 
 ## Usage

--- a/js/vd-editor.js
+++ b/js/vd-editor.js
@@ -1,6 +1,6 @@
 // Admin D3 editor with basic add/connect functionality
 (function($){
-    var textarea = document.querySelector('textarea[name="vd_tree_data"]');
+    var textarea = document.querySelector('textarea[name="vd_diagram_data"]');
     if (!textarea) return;
 
     var data;
@@ -70,7 +70,7 @@
         var nodeEnter = nodeSel.enter().append('g').attr('class', 'node');
         nodeEnter.append('circle')
             .attr('r', 20)
-            .attr('fill', '#aaf');
+            .attr('fill', function(d){ return d.content ? '#afa' : '#aaf'; });
         nodeEnter.append('text')
             .attr('text-anchor', 'middle')
             .attr('dy', 4)
@@ -81,14 +81,16 @@
             return 'translate(' + d.x + ',' + d.y + ')';
         });
 
-        nodeSel.select('circle').call(d3.drag()
-            .on('drag', function(event, d) {
-                d.x = event.x;
-                d.y = event.y;
-                d3.select(this.parentNode)
-                    .attr('transform', 'translate(' + d.x + ',' + d.y + ')');
-                render();
-                save();
+        nodeSel.select('circle')
+            .attr('fill', function(d){ return d.content ? '#afa' : '#aaf'; })
+            .call(d3.drag()
+                .on('drag', function(event, d) {
+                    d.x = event.x;
+                    d.y = event.y;
+                    d3.select(this.parentNode)
+                        .attr('transform', 'translate(' + d.x + ',' + d.y + ')');
+                    render();
+                    save();
             })
         );
 
@@ -107,8 +109,12 @@
             if (t !== null) {
                 d.text = t;
                 d3.select(this).select('text').text(t);
-                save();
             }
+            var content = prompt('Terminal content (leave empty for question)', d.content || '');
+            if (content !== null) {
+                d.content = content;
+            }
+            save();
         });
 
         nodeSel.exit().remove();
@@ -122,6 +128,9 @@
             y: coords[1],
             text: 'Question'
         };
+        if(data.nodes.length === 0){
+            node.isStart = true;
+        }
         data.nodes.push(node);
         render();
         save();

--- a/js/vd-frontend.js
+++ b/js/vd-frontend.js
@@ -1,4 +1,3 @@
-// Frontend diagram display using D3
 (function(){
     document.querySelectorAll('.vd-diagram').forEach(function(container){
         var dataAttr = container.getAttribute('data-diagram');
@@ -14,61 +13,45 @@
         data.nodes = data.nodes || [];
         data.links = data.links || [];
 
-        var width = container.clientWidth || 600;
-        var height = 400;
-
-        var svg = d3.select(container).append('svg')
-            .attr('width', width)
-            .attr('height', height);
-
-        function findNode(id) {
-            return data.nodes.find(function(n) { return n.id === id; });
+        function findNode(id){
+            return data.nodes.find(function(n){ return n.id === id; });
         }
 
-        // Render links with labels
-        var linkSel = svg.selectAll('g.link')
-            .data(data.links)
-            .enter()
-            .append('g')
-            .attr('class', 'link');
+        function outgoing(id){
+            return data.links.filter(function(l){ return l.source === id; });
+        }
 
-        linkSel.append('line')
-            .attr('stroke', '#000')
-            .attr('x1', function(d){ return findNode(d.source).x; })
-            .attr('y1', function(d){ return findNode(d.source).y; })
-            .attr('x2', function(d){ return findNode(d.target).x; })
-            .attr('y2', function(d){ return findNode(d.target).y; });
+        var current = data.nodes.find(function(n){ return n.isStart; }) || data.nodes[0];
+        if(!current) return;
 
-        linkSel.append('text')
-            .attr('text-anchor', 'middle')
-            .attr('dy', -5)
-            .attr('x', function(d){
-                var s = findNode(d.source), t = findNode(d.target);
-                return (s.x + t.x) / 2;
-            })
-            .attr('y', function(d){
-                var s = findNode(d.source), t = findNode(d.target);
-                return (s.y + t.y) / 2;
-            })
-            .text(function(d){ return d.label || ''; });
-
-        // Render nodes
-        var node = svg.selectAll('g.node')
-            .data(data.nodes)
-            .enter()
-            .append('g')
-            .attr('class', 'node')
-            .attr('transform', function(d){
-                return 'translate(' + d.x + ',' + d.y + ')';
+        function render(node){
+            container.innerHTML = '';
+            var options = outgoing(node.id);
+            if(options.length === 0){
+                var endDiv = document.createElement('div');
+                endDiv.className = 'vd-terminal';
+                endDiv.innerHTML = node.content || '';
+                container.appendChild(endDiv);
+                return;
+            }
+            var q = document.createElement('div');
+            q.className = 'vd-question';
+            q.textContent = node.text || node.label || '';
+            container.appendChild(q);
+            options.forEach(function(link){
+                var btn = document.createElement('button');
+                btn.textContent = link.label || '...';
+                btn.addEventListener('click', function(){
+                    var next = findNode(link.target);
+                    if(next){
+                        current = next;
+                        render(next);
+                    }
+                });
+                container.appendChild(btn);
             });
+        }
 
-        node.append('circle')
-            .attr('r', 20)
-            .attr('fill', '#aaf');
-
-        node.append('text')
-            .attr('text-anchor', 'middle')
-            .attr('dy', 4)
-            .text(function(d){ return d.text; });
+        render(current);
     });
 })();

--- a/visual-decisions.php
+++ b/visual-decisions.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Visual Decisions
-Description: Create visual decision trees with diagram editor and shortcode support.
+Description: Create visual decision trees with a diagram editor and render them as interactive questionnaires via shortcode.
 Version: 0.1.0
 Author: Auto Generated
 */
@@ -44,9 +44,9 @@ function vd_add_diagram_metabox() {
 add_action( 'add_meta_boxes', 'vd_add_diagram_metabox' );
 
 function vd_diagram_metabox_html( $post ) {
-    $data = get_post_meta( $post->ID, '_vd_tree_data', true );
+    $data = get_post_meta( $post->ID, '_vd_diagram_data', true );
     wp_nonce_field( 'vd_save_diagram', 'vd_diagram_nonce' );
-    echo '<textarea name="vd_tree_data" style="display:none;">' . esc_textarea( $data ) . '</textarea>';
+    echo '<textarea name="vd_diagram_data" style="display:none;">' . esc_textarea( $data ) . '</textarea>';
     echo '<div id="vd-editor" style="margin-top:10px;"></div>';
     echo '<p>Use the editor above to arrange your diagram.</p>';
 }
@@ -56,8 +56,8 @@ function vd_save_diagram_meta( $post_id ) {
         return;
     }
 
-    if ( isset( $_POST['vd_tree_data'] ) ) {
-        update_post_meta( $post_id, '_vd_tree_data', wp_unslash( $_POST['vd_tree_data'] ) );
+    if ( isset( $_POST['vd_diagram_data'] ) ) {
+        update_post_meta( $post_id, '_vd_diagram_data', wp_unslash( $_POST['vd_diagram_data'] ) );
     }
 }
 add_action( 'save_post_vd_diagram', 'vd_save_diagram_meta' );
@@ -70,7 +70,7 @@ function vd_diagram_shortcode( $atts ) {
         return '';
     }
 
-    $data = get_post_meta( $id, '_vd_tree_data', true );
+    $data = get_post_meta( $id, '_vd_diagram_data', true );
     if ( ! $data ) {
         return '';
     }
@@ -93,8 +93,6 @@ add_action( 'admin_enqueue_scripts', 'vd_admin_scripts' );
 
 // Enqueue D3 and renderer for frontend
 function vd_frontend_scripts() {
-    $d3_path = plugins_url( 'js/d3.min.js', __FILE__ );
-    wp_enqueue_script( 'd3', $d3_path );
-    wp_enqueue_script( 'vd-frontend', plugins_url( 'js/vd-frontend.js', __FILE__ ), array( 'd3' ), '0.1', true );
+    wp_enqueue_script( 'vd-frontend', plugins_url( 'js/vd-frontend.js', __FILE__ ), array(), '0.1', true );
 }
 add_action( 'wp_enqueue_scripts', 'vd_frontend_scripts' );


### PR DESCRIPTION
## Summary
- create an interactive questionnaire viewer in `vd-frontend.js`
- mark first node as start and allow terminal text in `vd-editor.js`
- store diagram JSON under `_vd_diagram_data`
- update plugin description and docs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68631234f0d4832a8a3e33cae3713c5d