### PR TITLE
Add admin editor height styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ The editor lets you build a flow of multiple-choice questions and the front-end 
 
 The plugin enqueues a bundled copy of the GoJS library in both the admin and the front‑end. The accompanying JavaScript files (`vd-editor.js` and `vd-frontend.js`) handle basic editing and rendering of diagrams.
 
+The admin editor (`#vd-editor`) defaults to a height of **400px** defined in `css/admin.css`. Adjust this value in the stylesheet if you need a taller or shorter editor area.
+

--- a/css/admin.css
+++ b/css/admin.css
@@ -1,0 +1,3 @@
+#vd-editor {
+    height: 400px;
+}

--- a/visual-decisions.php
+++ b/visual-decisions.php
@@ -85,6 +85,7 @@ function vd_admin_scripts( $hook ) {
     if ( isset( $screen->post_type ) && $screen->post_type === 'vd_diagram' ) {
         wp_enqueue_script( 'gojs', plugins_url( 'js/go.js', __FILE__ ) );
         wp_enqueue_script( 'vd-editor', plugins_url( 'js/vd-editor.js', __FILE__ ), array( 'gojs', 'jquery' ), '0.1', true );
+        wp_enqueue_style( 'vd-admin', plugins_url( 'css/admin.css', __FILE__ ), array(), '0.1' );
     }
 }
 add_action( 'admin_enqueue_scripts', 'vd_admin_scripts' );


### PR DESCRIPTION
## Summary
- add stylesheet for the admin editor
- enqueue admin stylesheet when editing diagrams
- document default height in README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68648b787ce0832aaec443627a42cd2e